### PR TITLE
fix: autofocus

### DIFF
--- a/src/lib/components/Searchbox.svelte
+++ b/src/lib/components/Searchbox.svelte
@@ -18,6 +18,7 @@
 		spellcheck="false"
 		autocorrect="off"
 		dir="auto"
+		autofocus
 		bind:value={query}
 	/>
 	<!-- <button


### PR DESCRIPTION
A warning is thrown due to [guidelines](https://www.a11yproject.com/checklist/#avoid-using-the-autofocus-attribute), but can be ignored.

Idea of having focus on load with the [autofocus](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus) property may prove acceptable. It does not disrupt accessibility in this instance according to [WCAG](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-focus-order.html).