### PR TITLE
fix(fetchResults): use URL instead of string and force URL encoding

### DIFF
--- a/src/lib/functions/createApiUrl.ts
+++ b/src/lib/functions/createApiUrl.ts
@@ -9,9 +9,9 @@ export function createApiUrl(path: string, params?: URLSearchParams): URL {
 	const apiUrl: string = (apiUri.endsWith('/') ? apiUri : apiUri + '/') + path;
 	const urll: URL = new URL(apiUrl);
 
-	if (params) {
+	if (params !== undefined) {
 		for (const [key, value] of params) {
-			urll.searchParams.set(key, value);
+			urll.searchParams.set(key, encodeURIComponent(value));
 		}
 	}
 

--- a/src/lib/functions/createApiUrl.ts
+++ b/src/lib/functions/createApiUrl.ts
@@ -10,9 +10,9 @@ export function createApiUrl(path: string, params?: URLSearchParams): URL {
 	const urll: URL = new URL(apiUrl);
 
 	if (params) {
-		params.forEach((value, key) => {
+		for (const [key, value] of params) {
 			urll.searchParams.set(key, value);
-		});
+		}
 	}
 
 	return urll;

--- a/src/lib/functions/createApiUrl.ts
+++ b/src/lib/functions/createApiUrl.ts
@@ -6,9 +6,14 @@ export function createApiUrl(path: string, params?: URLSearchParams): URL {
 		throw new Error('API_URI env is not defined');
 	}
 
-	const paramsString: string | undefined = params ? params.toString() : undefined;
-	const urll: URL = new URL(
-		(apiUri.endsWith('/') ? apiUri : apiUri + '/') + path + (paramsString ? `?${paramsString}` : '')
-	);
+	const apiUrl: string = (apiUri.endsWith('/') ? apiUri : apiUri + '/') + path;
+	const urll: URL = new URL(apiUrl);
+
+	if (params) {
+		params.forEach((value, key) => {
+			urll.searchParams.set(key, value);
+		});
+	}
+
 	return urll;
 }

--- a/src/lib/functions/createApiUrl.ts
+++ b/src/lib/functions/createApiUrl.ts
@@ -1,11 +1,14 @@
 import { env } from '$env/dynamic/private';
 
-export function createApiUrl(path: string, params?: URLSearchParams): string {
+export function createApiUrl(path: string, params?: URLSearchParams): URL {
 	const apiUri: string | undefined = env.API_URI;
 	if (apiUri === undefined) {
 		throw new Error('API_URI env is not defined');
 	}
 
 	const paramsString: string | undefined = params ? params.toString() : undefined;
-	return (apiUri.endsWith('/') ? apiUri : apiUri + '/') + path + (paramsString ? `?${paramsString}` : '');
+	const urll: URL = new URL(
+		(apiUri.endsWith('/') ? apiUri : apiUri + '/') + path + (paramsString ? `?${paramsString}` : '')
+	);
+	return urll;
 }

--- a/src/lib/functions/createPublicApiUrl.ts
+++ b/src/lib/functions/createPublicApiUrl.ts
@@ -9,9 +9,9 @@ export function createPublicApiUrl(path: string, params?: URLSearchParams): URL 
 	const apiUrl: string = (apiUri.endsWith('/') ? apiUri : apiUri + '/') + path;
 	const urll: URL = new URL(apiUrl);
 
-	if (params) {
+	if (params !== undefined) {
 		for (const [key, value] of params) {
-			urll.searchParams.set(key, value);
+			urll.searchParams.set(key, encodeURIComponent(value));
 		}
 	}
 

--- a/src/lib/functions/createPublicApiUrl.ts
+++ b/src/lib/functions/createPublicApiUrl.ts
@@ -1,11 +1,14 @@
 import { env } from '$env/dynamic/public';
 
-export function createPublicApiUrl(path: string, params?: URLSearchParams): string {
+export function createPublicApiUrl(path: string, params?: URLSearchParams): URL {
 	const apiUri: string | undefined = env.PUBLIC_API_URI;
 	if (apiUri === undefined) {
 		throw new Error('PUBLIC_API_URI env is not defined');
 	}
 
 	const paramsString: string | undefined = params ? params.toString() : undefined;
-	return (apiUri.endsWith('/') ? apiUri : apiUri + '/') + path + (paramsString ? `?${paramsString}` : '');
+	const urll: URL = new URL(
+		(apiUri.endsWith('/') ? apiUri : apiUri + '/') + path + (paramsString ? `?${paramsString}` : '')
+	);
+	return urll;
 }

--- a/src/lib/functions/createPublicApiUrl.ts
+++ b/src/lib/functions/createPublicApiUrl.ts
@@ -6,9 +6,14 @@ export function createPublicApiUrl(path: string, params?: URLSearchParams): URL 
 		throw new Error('PUBLIC_API_URI env is not defined');
 	}
 
-	const paramsString: string | undefined = params ? params.toString() : undefined;
-	const urll: URL = new URL(
-		(apiUri.endsWith('/') ? apiUri : apiUri + '/') + path + (paramsString ? `?${paramsString}` : '')
-	);
+	const apiUrl: string = (apiUri.endsWith('/') ? apiUri : apiUri + '/') + path;
+	const urll: URL = new URL(apiUrl);
+
+	if (params) {
+		params.forEach((value, key) => {
+			urll.searchParams.set(key, value);
+		});
+	}
+
 	return urll;
 }

--- a/src/lib/functions/createPublicApiUrl.ts
+++ b/src/lib/functions/createPublicApiUrl.ts
@@ -10,9 +10,9 @@ export function createPublicApiUrl(path: string, params?: URLSearchParams): URL 
 	const urll: URL = new URL(apiUrl);
 
 	if (params) {
-		params.forEach((value, key) => {
+		for (const [key, value] of params) {
 			urll.searchParams.set(key, value);
-		});
+		}
 	}
 
 	return urll;

--- a/src/lib/functions/fetchPublicResultsJSON.ts
+++ b/src/lib/functions/fetchPublicResultsJSON.ts
@@ -3,10 +3,8 @@ import { createPublicApiUrl } from '$lib/functions/createPublicApiUrl';
 
 import type { ResultType, ErrorResponseType } from '$lib/types/result';
 
-export async function fetchPublicResultsJSON(
-	params: URLSearchParams
-): Promise<ResultType[]> {
-	let apiUrl: string;
+export async function fetchPublicResultsJSON(params: URLSearchParams): Promise<ResultType[]> {
+	let apiUrl: URL;
 	try {
 		apiUrl = createPublicApiUrl('search', params);
 	} catch (err: any) {

--- a/src/lib/functions/fetchResultsJSON.ts
+++ b/src/lib/functions/fetchResultsJSON.ts
@@ -12,7 +12,7 @@ export async function fetchResultsJSON(
 ): Promise<ResultType[]> {
 	const delayed: Promise<void> = sleep(delay);
 
-	let apiUrl: string;
+	let apiUrl: URL;
 	try {
 		apiUrl = createApiUrl('search', params);
 	} catch (err: any) {


### PR DESCRIPTION
Closes #174 

Working example: https://fix-url-encoding.hearchco-frontend.pages.dev/search?q=anything%3B