### PR TITLE
feat: show more images form enhance

### DIFF
--- a/src/lib/components/search/display/images/Image.svelte
+++ b/src/lib/components/search/display/images/Image.svelte
@@ -27,7 +27,7 @@
 		class:ring-4={selected}
 		class:ring-hearchco-primary={selected}
 		class:dark:ring-hearchco-secondary={selected}
-		class="w-full h-full overflow-hidden hover:scale-110 relative z-0 hover:z-50 hover:ring-4 hover:ring-gray-300 hover:dark:ring-gray-100 transform delay-150 duration-300 ease-in-out rounded-lg shadow-sm dark:shadow-none"
+		class="w-full h-full overflow-hidden hover:scale-110 relative z-0 hover:z-50 hover:ring-4 hover:ring-gray-300 hover:dark:ring-gray-100 transform delay-75 duration-300 ease-in-out rounded-lg shadow-sm dark:shadow-none"
 		on:click={() => openImage()}
 	>
 		<img

--- a/src/lib/components/search/display/images/Image.svelte
+++ b/src/lib/components/search/display/images/Image.svelte
@@ -10,7 +10,7 @@
 
 	// variables
 	const loading: 'eager' | 'lazy' | null | undefined = result.rank > 10 ? 'lazy' : 'eager';
-	$: selected = imgResultPreview === result;
+	$: selected = imgResultPreview?.url === result.url;
 
 	// functions
 	function openImage() {

--- a/src/lib/components/search/display/images/Images.svelte
+++ b/src/lib/components/search/display/images/Images.svelte
@@ -31,7 +31,7 @@
 			<Preview result={imgResultPreview} bind:imgResultPreview />
 		</div>
 	{/if}
-	<!-- <div class="w-full">
+	<div class="w-full">
 		<section
 			id="images"
 			class="grid sm:grid-cols-fit grid-cols-sm-fit sm:auto-rows-[168px] auto-rows-[28dvw] grid-flow-dense gap-2"
@@ -50,7 +50,7 @@
 				</div>
 			{/each}
 		</section>
-	</div> -->
+	</div>
 	<!-- preview on left when screen width >= lg -->
 	{#if imgResultPreview !== undefined}
 		<div id="image-preview" class="hidden lg:block w-1/2">

--- a/src/lib/components/search/display/images/Images.svelte
+++ b/src/lib/components/search/display/images/Images.svelte
@@ -31,7 +31,7 @@
 			<Preview result={imgResultPreview} bind:imgResultPreview />
 		</div>
 	{/if}
-	<div class="w-full">
+	<!-- <div class="w-full">
 		<section
 			id="images"
 			class="grid sm:grid-cols-fit grid-cols-sm-fit sm:auto-rows-[168px] auto-rows-[28dvw] grid-flow-dense gap-2"
@@ -50,7 +50,7 @@
 				</div>
 			{/each}
 		</section>
-	</div>
+	</div> -->
 	<!-- preview on left when screen width >= lg -->
 	{#if imgResultPreview !== undefined}
 		<div id="image-preview" class="hidden lg:block w-1/2">

--- a/src/lib/components/search/display/images/ShowMore.svelte
+++ b/src/lib/components/search/display/images/ShowMore.svelte
@@ -41,7 +41,7 @@
 	<input type="hidden" name="pages" value={pages} />
 	<button
 		type="submit"
-		class="mx-auto mb-5 h-12 w-1/5 rounded-lg overflow-hidden dark:bg-zinc-800 hover:dark:bg-zinc-700 hover:ring-2 hover:ring-hearchco-primary hover:dark:ring-hearchco-secondary text-zinc-500 dark:text-zinc-200 hover:text-hearchco-primary hover:dark:text-hearchco-secondary shadow-sm dark:shadow-none border border-gray-100 dark:border-0 duration-200 ease-in-out"
+		class="mx-auto mb-5 h-12 w-1/2 sm:w-1/3 lg:w-1/4 2xl:w-1/5 rounded-lg overflow-hidden dark:bg-zinc-800 hover:dark:bg-zinc-700 hover:ring-2 hover:ring-hearchco-primary hover:dark:ring-hearchco-secondary text-zinc-500 dark:text-zinc-200 hover:text-hearchco-primary hover:dark:text-hearchco-secondary shadow-sm dark:shadow-none border border-gray-100 dark:border-0 duration-200 ease-in-out"
 	>
 		Show more
 	</button>

--- a/src/lib/components/search/display/images/ShowMore.svelte
+++ b/src/lib/components/search/display/images/ShowMore.svelte
@@ -16,8 +16,8 @@
 	let pages: number = 2;
 
 	// functions
-	const handleSubmit = async () => {
-		const [newOffset, newResults]: [number, ResultType[]] = await fetchResultsLazily(
+	async function handleSubmit() {
+		const [newOffset, newResults] = await fetchResultsLazily(
 			query,
 			start,
 			offset,
@@ -27,7 +27,7 @@
 		);
 		offset = newOffset;
 		results = newResults;
-	};
+	}
 </script>
 
 <form

--- a/src/lib/components/search/display/images/ShowMore.svelte
+++ b/src/lib/components/search/display/images/ShowMore.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	// functions
-	import { fetchResultsLazily } from "$lib/functions/fetchResultsLazily";
+	import { fetchResultsLazily } from '$lib/functions/fetchResultsLazily';
 
 	// types
-	import type { ResultType } from "$lib/types/result";
+	import type { ResultType } from '$lib/types/result';
 
 	// parameters
 	export let query: string;
@@ -16,20 +16,33 @@
 	let pages: number = 2;
 
 	// functions
-	const showMore = async () => {
-		const [newOffset, newResults]: [number, ResultType[]] = await fetchResultsLazily(query, start, offset, pages, results, paramsString);
+	const handleSubmit = async () => {
+		const [newOffset, newResults]: [number, ResultType[]] = await fetchResultsLazily(
+			query,
+			start,
+			offset,
+			pages,
+			results,
+			paramsString
+		);
 		offset = newOffset;
 		results = newResults;
 	};
 </script>
 
-<!-- TODO: revert back to form for no-JS users but use enhancing to load the results lazily like below -->
-<div class="pb-5 flex flex-row justify-center">
+<form
+	on:submit|preventDefault={handleSubmit}
+	method="get"
+	action="/search"
+	class="pb-5 flex flex-row justify-center"
+>
+	<input type="hidden" name="q" value={query} />
+	<input type="hidden" name="start" value={start + offset} />
+	<input type="hidden" name="pages" value={pages} />
 	<button
-		on:click={showMore}
-		type="button"
+		type="submit"
 		class="mx-auto mb-5 h-12 w-1/5 rounded-lg overflow-hidden dark:bg-zinc-800 hover:dark:bg-zinc-700 hover:ring-2 hover:ring-hearchco-primary hover:dark:ring-hearchco-secondary text-zinc-500 dark:text-zinc-200 hover:text-hearchco-primary hover:dark:text-hearchco-secondary shadow-sm dark:shadow-none border border-gray-100 dark:border-0 duration-200 ease-in-out"
 	>
 		Show more
 	</button>
-</div>
+</form>

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -14,10 +14,10 @@
 
 	// variables
 	let query = data.query;
-	let currentPage = data.currentPage;
-	let paramsString = data.params;
+	$: currentPage = data.currentPage;
+	$: paramsString = data.params;
 	// TODO: implement a option for setting maxPages, allowing user to choose how much results to show
-	// let maxPages = data.maxPages;
+	// $: maxPages = data.maxPages;
 	$: title = query === '' ? 'Hearchco Search' : `${query} | Hearchco Search`;
 
 	// snapshots


### PR DESCRIPTION
- [x] Make Show more images button nicer on mobile
- [x] Switch to form with enhanced submit prevent (to maintain JS niceness lazy loading but to also support non-JS)
~~- [ ] Add form params to URL without doing a full page load~~ Should be done in a separate rewrite of frontend with better understanding of SvelteKit state management