### PR TITLE
fix(themetoggle): better reactivity code, watching system state and default dark

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/lib/components/themetoggle/main.svelte
+++ b/src/lib/components/themetoggle/main.svelte
@@ -18,7 +18,6 @@
 	onMount(() => {
 		const media = window.matchMedia('(prefers-color-scheme: dark)');
 		system = media.matches ? 'dark' : 'light';
-		// Update system theme when it changes.
 		media.addEventListener('change', (e) => {
 			system = e.matches ? 'dark' : 'light';
 		});
@@ -66,7 +65,7 @@
 	<script>
 		const selected = localStorage.getItem('theme') ?? 'system';
 		const system = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-		const theme = selected !== 'system' ? selected : system;
+		const theme = selected === 'system' ? system : selected;
 		if (theme === 'dark') document.documentElement.classList.add('dark');
 	</script>
 </svelte:head>


### PR DESCRIPTION
- [x] Dark theme by default, so that noJS users get the dark theme
- [x] Better reactivity to make the theme toggle code more readable
- [x] Update the system theme when it changes
- [x] Double click on theme toggle button to clear the set theme (making it follow system again)